### PR TITLE
Removed window decorations using flags for parent view

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -8,10 +8,11 @@
 int main(int argc, char *argv[])
 {
     setenv("QT_QPA_PLATFORM", "wayland", 1); // force to use wayland plugin
-    setenv("QT_WAYLAND_DISABLE_WINDOWDECORATION", "1", 1);
+    //setenv("QT_WAYLAND_DISABLE_WINDOWDECORATION", "1", 1);
     QGuiApplication app(argc, argv);
     qmlRegisterType<dbushelper>("Dbushelper", 1, 0, "Dbushelper");      //create QML object Mytime (first character has to be UPPERCASE!!) from C++ class
     QQuickView view;
+    view.setFlags(Qt::FramelessWindowHint | Qt::Window);
     view.engine()->addImportPath(QCoreApplication::applicationDirPath() + "/imports");
     view.setSource(QUrl(QStringLiteral("qrc:/Main.qml")));
     view.setProperty("IVI-Surface-ID", HVAC_POC_SURFACE_ID);


### PR DESCRIPTION
On some hardware with wayland backend the GUI is not visible using QT_WAYLAND_DISABLE_WINDOWDECORATION environment variable. So, I commented the line that sets this variable and I removed the window decoration using flags for the parent view.