### PR TITLE
manifest: Change to .desktop format

### DIFF
--- a/com.genivi.gdp.hvac.desktop
+++ b/com.genivi.gdp.hvac.desktop
@@ -1,4 +1,6 @@
+[Desktop Entry]
 Name=Climate Controls
+Type=Application
 Icon=file://opt/com.genivi.gdp.hvac/share/icons/com.genivi.gdp.hvac.svg
 Unit=com.genivi.gdp.hvac
-Exec=/opt/com.genivi.gdp.hvac/bin/HVAC_rvi_vtc1010
+Exec=/opt/com.genivi.gdp.hvac/bin/HVAC_rvi_vtc1010 -platform wayland

--- a/com.genivi.gdp.hvac.service
+++ b/com.genivi.gdp.hvac.service
@@ -1,6 +1,0 @@
-[Unit]
-Description=Climate Control Application
-
-[Service]
-Environment=LD_PRELOAD=/usr/lib/libEGL.so
-ExecStart=/opt/com.genivi.gdp.hvac/bin/HVAC_rvi_vtc1010 -platform wayland


### PR DESCRIPTION
Remove .service file as it is no longer used by the HMI
Reformat .app file in to a .desktop file

[GDP-555] Mechanism to register & launch apps in HMI

Signed-off-by: Viktor Sjölind <viktor.sjolind@pelagicore.com>